### PR TITLE
Added a random suffix to class names to avoid multiple RCSS collisions

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ var existingClasses = {};
 var styleTag = createStyleTag();
 
 var classNameId = 0;
+var randomSuffix = Math.random().toString(36).slice(-5);
 
 function generateValidCSSClassName() {
   // CSS classNames can't start with a number.
-  return 'c' + (classNameId++);
+  return 'c' + (classNameId++) + '-' + randomSuffix;
 }
 
 function objToCSS(style) {


### PR DESCRIPTION
I went with a 5-character random suffix to avoid collisions when using multiple "instances" of RCSS. Closes #21.
