### PR TITLE
use an internal registry instead of globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 var cascade = require('./cascade');
 var registerClass = require('./registerClass');
 var styleRuleConverter = require('./styleRuleConverter');
-
-var global = Function("return this")();
-global.__RCSS_0_registry = global.__RCSS_0_registry || {};
+var globalRegistry = require('./registry');
 
 function descriptorsToString(styleDescriptor) {
   return styleRuleConverter.rulesToString(
@@ -23,7 +21,7 @@ var RCSS = {
   },
 
   getStylesString: function() {
-    var registry = global.__RCSS_0_registry;
+    var registry = globalRegistry.registry;
     var str = '';
     for (var key in registry) {
       if (!registry.hasOwnProperty(key)) {
@@ -31,7 +29,7 @@ var RCSS = {
       }
       str += descriptorsToString(registry[key]);
     }
-    global.__RCSS_0_registry = {};
+    globalRegistry.registry = {};
     return str;
   }
 };

--- a/registerClass.js
+++ b/registerClass.js
@@ -1,4 +1,5 @@
 var sha1 = require('sha1');
+var globalRegistry = require('./registry');
 
 function hashStyle(styleObj) {
   return sha1(JSON.stringify(styleObj));
@@ -9,21 +10,18 @@ function generateValidCSSClassName(styleId) {
   return 'c' + styleId;
 }
 
-var global = Function("return this")();
-global.__RCSS_0_registry = global.__RCSS_0_registry || {};
-
 function registerClass(styleObj) {
   var styleId = generateValidCSSClassName(hashStyle(styleObj));
 
-  if (global.__RCSS_0_registry[styleId] == null) {
-    global.__RCSS_0_registry[styleId] = {
+  if (globalRegistry.registry[styleId] == null) {
+    globalRegistry.registry[styleId] = {
       className: styleId,
       style: styleObj
     };
   }
 
   // Simple shallow clone
-  var styleObj = global.__RCSS_0_registry[styleId];
+  var styleObj = globalRegistry.registry[styleId];
   return {
     className: styleObj.className,
     style: styleObj.style

--- a/registry.js
+++ b/registry.js
@@ -1,0 +1,1 @@
+exports.registry = {};


### PR DESCRIPTION
I wasn't really sure why there was a global registry variable? So I refactored it into something a little safer. (Unless you're explicitly trying to support multiple versions of RCSS at the same time in the future or something?)
