### PR TITLE
Update readme require('RCSS') example to be lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Demo of the example folder output [here](https://rawgit.com/chenglou/RCSS/master
 
 button.js:
 ```js
-var RCSS = require('RCSS');
+var RCSS = require('rcss');
 
 var button = {
   display: 'inline-block',


### PR DESCRIPTION
I ran into an issue with this where I likely copy and pasted directly from the README which eventually lead to `MODULE_NOT_FOUND` errors in another environment. Hopefully this saves someone else a little bit of time.

Awesome project!